### PR TITLE
Freeze phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "shelljs": "^0.5.3"
   },
   "peerDependencies": {
-    "phantomjs": ">=1.9"
+    "phantomjs": "^1.9"
   },
   "devDependencies": {
     "eslint": "^1.8.0"


### PR DESCRIPTION
Phantomjs 2+ does not work with grunticon currently, need to fix the version.
